### PR TITLE
FPS counter

### DIFF
--- a/lib/core_ext/array.rb
+++ b/lib/core_ext/array.rb
@@ -1,0 +1,9 @@
+class Array
+  def sum
+    inject(0.0) { |sum, el| sum += el }
+  end
+
+  def mean
+    sum / size
+  end
+end

--- a/lib/theia.rb
+++ b/lib/theia.rb
@@ -6,6 +6,7 @@ require 'yaml'
 require 'fileutils'
 
 require_relative 'core_ext/log4r/outputter/uniqueoutputter'
+require_relative 'core_ext/array'
 
 require_relative 'theia/helpers'
 require_relative 'theia/occurrence'

--- a/lib/theia/mode/game.rb
+++ b/lib/theia/mode/game.rb
@@ -79,6 +79,9 @@ module Theia
               @pieces << occurrence.piece.key
             end
 
+            # Draw the FPS indicator on the upper right corner.
+            frame.draw_label("FPS: %.2f" % @fps, Point.new(frame.cols - 80, 20), )
+
             board_window.show(frame)
 
             output_diff


### PR DESCRIPTION
Added an FPS counter that shows on game mode video feed.

The reason why this didn't end up on the logs was because it would make them really noisy with information that we don't care about most of the time.

Closes #26.
